### PR TITLE
Fix TOC generation in HTML output

### DIFF
--- a/GeoTIFF_Standard/standard/GeoTiff.adoc
+++ b/GeoTIFF_Standard/standard/GeoTiff.adoc
@@ -3,11 +3,14 @@
 :doctype: book
 :encoding: utf-8
 :lang: en
+:toc:
+:toclevels: 3
+:toc-placement!:
 :sectanchors:
 :source-highlighter: pygments
 :numbered:
 
-= {title}
+= OGC GeoTIFF Standard
 
 <<<
 [cols = ">",frame = "none",grid = "none"]
@@ -67,10 +70,6 @@ Recipients of this document are invited to submit, with their comments, notifica
 [small]#This license is effective until terminated. You may terminate it at any time by destroying the Intellectual Property together with all copies in any form. The license will also terminate if you fail to comply with any term or condition of this Agreement. Except as provided in the following sentence, no such termination of this license shall require the termination of any third party end-user sublicense to the Intellectual Property which is in force as of the date of notice of such termination. In addition, should the Intellectual Property, or the operation of the Intellectual Property, infringe, or in LICENSOR's sole opinion be likely to infringe, any patent, copyright, trademark or other right of a third party, you agree that LICENSOR, in its sole discretion, may terminate this license without any compensation or liability to you, your licensees or any other party. You agree upon termination of any kind to destroy or cause to be destroyed the Intellectual Property together with all copies in any form, whether held by you or by any third party.#
 
 [small]#Except as contained in this notice, the name of LICENSOR or of any other holder of a copyright in all or part of the Intellectual Property shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Intellectual Property without prior written authorization of LICENSOR or such copyright holder. LICENSOR is and shall at all times be the sole entity that may authorize you or any third party to use certification marks, trademarks or other special designations to indicate compliance with any LICENSOR standards or specifications. This Agreement is governed by the laws of the Commonwealth of Massachusetts. The application to this Agreement of the United Nations Convention on Contracts for the International Sale of Goods is hereby expressly excluded. In the event any provision of this Agreement shall be deemed unenforceable, void or invalid, such provision shall be modified so as to make it valid and enforceable, and as so modified the entire Agreement shall remain in full force and effect. No decision, action or inaction by LICENSOR shall be construed to be a waiver of any rights or remedies available to it.#
-
-:toc:
-:toc-placement:
-:toclevels: 3
 
 <<<
 toc::[]

--- a/GeoTIFF_Standard/standard/annex-b.adoc
+++ b/GeoTIFF_Standard/standard/annex-b.adoc
@@ -207,7 +207,7 @@ It has been found that an oblate ellipsoid (an ellipse rotated about its minor a
 
 Other ellipsoid parameters needed for cartographic applications, for example the eccentricity, can easily be calculated from the two defining parameters. Note that GeoTIFF uses the modern geodesy convention for the symbol (b) for the semi-minor axis. No provision is made for mapping other planets in which a tri-dimensional (tri-axial) ellipsoid might be required, where (b) would represent the semi-median axis and (c) the semi-minor axis.
 
-Historical models exist which use a spherical approximation; such models are not recommended for modern applications, but if needed the size of a model sphere may be defined by specifying identical values for the semi-major and semi-minor axes; the inverse flattening cannot be used as it becomes infinite for a +++<u>perfect sphere</u>+++.
+Historical models exist which use a spherical approximation; such models are not recommended for modern applications, but if needed the size of a model sphere may be defined by specifying identical values for the semi-major and semi-minor axes; the inverse flattening cannot be used as it becomes infinite for a perfect sphere.
 
 ===== Prime Meridian
 The coordinate axes of the system referencing points on an ellipsoid are called latitude and longitude. More precisely, geodetic latitude and longitude are required in this GeoTIFF standard. A discussion of the several other types of latitude and longitude is beyond the scope of this document as they are not required for conventional georeferencing.


### PR DESCRIPTION
Repairs TOC generation for HTML output with asciidoctor 1.5.4
Also fixes warning for PDF generation in annex-b.adoc, and expand {title} so that it appears correctly in the PDF TOC