### PR TITLE
Adding suport for GeoLongParamsTag

### DIFF
--- a/GeoTIFF_Standard/standard/abstract_tests/TIFF_Tests/TEST_GeoKeyDirectory.adoc
+++ b/GeoTIFF_Standard/standard/abstract_tests/TIFF_Tests/TEST_GeoKeyDirectory.adoc
@@ -57,6 +57,7 @@
          IF value = 0 THEN Execute test http://www.opengis.net/spec/GeoTIFF/1.1/conf/Short_Param passing GeoKeyOffset as a parameter
          IF value = 34735 THEN Execute test http://www.opengis.net/spec/GeoTIFF/1.1/conf/Short_Param passing GeoKeyOffset as a parameter
          IF value = 34736 THEN Execute test http://www.opengis.net/spec/GeoTIFF/1.1/conf/Double_Param passing GeoKeyOffset as a parameter
+         IF value = 34738 THEN Execute test http://www.opengis.net/spec/GeoTIFF/1.1/conf/Long_Param passing GeoKeyOffset as a parameter
          IF value = 34737 THEN  Execute test http://www.opengis.net/spec/GeoTIFF/1.1/conf/ASCII_Param passing GeoKeyOffset as a parameter
          }
      SET GeoKeyOffset = GeoKeyOffset + 8

--- a/GeoTIFF_Standard/standard/abstract_tests/TIFF_Tests/TEST_TIFF_Tags.adoc
+++ b/GeoTIFF_Standard/standard/abstract_tests/TIFF_Tests/TEST_TIFF_Tags.adoc
@@ -73,6 +73,11 @@ Process each IFD using the following pseudocode:
             Validate that Bytes 2-3 = 12 (Double)
             Set DoubleValues to the value in Bytes 8-11
             }
+        IF value = 34738 THEN
+            {
+            Validate that Bytes 2-3 = 4 (Long or ULong)
+            Set LongValues to the value in Bytes 8-11
+            }
         IF value = 34737 THEN
             {
             Validate that Bytes 2-3 = 2 (ASCII)

--- a/GeoTIFF_Standard/standard/annex-b.adoc
+++ b/GeoTIFF_Standard/standard/annex-b.adoc
@@ -80,7 +80,7 @@ This header is immediately followed by a collection of <NumberOfKeys> KeyEntry s
 
 Following the KeyEntry definitions, the KeyDirectory tag may also contain additional values. For example, if a Key requires multiple SHORT values, they shall be placed at the end of this tag and the KeyEntry will set TIFFTagLocation=GeoKeyDirectoryTag, with the ValueOffset pointing to the location of the value(s).
 
-All key-values which are not of type SHORT are to be stored in one of the following two tags, based on their format:
+All key-values which are not of type SHORT are to be stored in one of the following three tags, based on their format:
 
  GeoDoubleParamsTag:
      Tag = 34736 (87BO.H)
@@ -88,6 +88,13 @@ All key-values which are not of type SHORT are to be stored in one of the follow
      N = variable
 
 This tag is used to store all of the DOUBLE valued GeoKeys, referenced by the GeoKeyDirectoryTag. The meaning of any value of this double array is determined from the GeoKeyDirectoryTag reference pointing to it. FLOAT values should first be converted to DOUBLE and stored here.
+
+GeoLongParamsTag:
+    Tag = 34738 (87B2.H)
+    Type = LONG (int32 or uint32)
+    N = variable
+
+This tag is used to store all of the LONG oand ULONG valued GeoKeys, referenced by the GeoKeyDirectoryTag. The meaning of any value of this long array is determined from the GeoKeyDirectoryTag reference pointing to it. The interpretation fot he bytes as LONG or ULONG depen on the datatype indicated in the GeoKeyDirectoryTag.
 
  GeoAsciiParamsTag:
      Tag = 34737 (87B1.H)

--- a/GeoTIFF_Standard/standard/clause_7_requirements.adoc
+++ b/GeoTIFF_Standard/standard/clause_7_requirements.adoc
@@ -51,6 +51,12 @@ The following requirements govern the storage of parameter values when there are
 
 include::requirements/TIFF_Requirements/requirements_class_GeoShortParamsTag.adoc[]
 
+==== Requirements Class GeoLongParamsTag
+
+The following requirements govern the storage of parameter values when  when the values are of type Long.
+
+include::requirements/TIFF_Requirements/requirements_class_GeoLongParamsTag.adoc[]
+
 ==== Requirements Class GeoDoubleParamsTag
 
 The following requirements govern the storage of parameter values when the values are of type Double.

--- a/GeoTIFF_Standard/standard/requirements/TIFF_Requirements/requirements_class_GeoLongParamsTag.adoc
+++ b/GeoTIFF_Standard/standard/requirements/TIFF_Requirements/requirements_class_GeoLongParamsTag.adoc
@@ -1,0 +1,16 @@
+[cols="1,4",width="90%"]
+|===
+2+|*Requirements Class 5.0: GeoLongParamsTag* {set:cellbgcolor:#CACCCE}
+2+|http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoLongParamsTag
+{set:cellbgcolor:#FFFFFF}
+
+|Requirement 5.1 {set:cellbgcolor:#CACCCE}
+|http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoLongParamsTag.ID +
+_The GeoLongParamsTag SHALL have ID = 34738_
+{set:cellbgcolor:#FFFFFF}
+
+|Requirement 5.2 {set:cellbgcolor:#CACCCE}
+|http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoLongParamsTag.count +
+_The GeoLongParamsTag MAY hold any number of key parameters with type = Long._
+{set:cellbgcolor:#FFFFFF}
+|===

--- a/GeoTIFF_Standard/standard/requirements/TIFF_Requirements/requirements_class_TIFF.adoc
+++ b/GeoTIFF_Standard/standard/requirements/TIFF_Requirements/requirements_class_TIFF.adoc
@@ -14,6 +14,7 @@ _A GeoTIFF file SHALL be compliant with the TIFF 6.0 specification_
 _GeoTIFF files SHALL encode all GeoTIFF specific information using the following specified reserved TIFF tags_ +
  - 34735  GeoKeyDirectoryTag (mandatory) +
  - 34736  GeoDoubleParamsTag (optional) +
+ - 34738  GeoLongParamsTag (optional) +
  - 34737  GeoAsciiParamsTag (optional) +
  - 33550  ModelPixelScaleTag (optional) +
  - 33922  ModelTiepointTag (conditional) +


### PR DESCRIPTION
In the COG standard draft created in the Testbed 17, we need new GeoTIFF tags. One of them needs to contain an array of long values. Unfortunately this was not foreseen in the current version of the GeoTIF 1.0 or 1.1. We request to extend the v1.2 with the support for this by adding a new TIFF tag called "GeoLongParamsTag" that will use the ID = 34738 that is the immediately available number after GeoAsciiParamsTag (ID = 34737). Please, consider it by adding support to bigTIFF, it is also necessary to have a an array of LONG8 (int64) values. This need has not emerged yet but it could.