### PR TITLE
GeoTiff.adoc: bump version to 1.2dev and mark undefined fields for now as TBD

### DIFF
--- a/GeoTIFF_Standard/standard/GeoTiff.adoc
+++ b/GeoTIFF_Standard/standard/GeoTiff.adoc
@@ -17,14 +17,14 @@
 |===
 |{set:cellbgcolor:#FFFFFF}
 |[big]*Open Geospatial Consortium*
-|Submission Date: 2019-06-05
-|Approval Date:   2019-09-10
-|Publication Date:   2019-09-14
-|External identifier of this OGC(R) document: http://www.opengis.net/doc/IS/GeoTIFF/1.1
-|Internal reference number of this OGC(R) document:    19-008r4
-|Version: 1.1
+|Submission Date: TBD
+|Approval Date:   TBD
+|Publication Date:   TBD
+|External identifier of this OGC(R) document: http://www.opengis.net/doc/IS/GeoTIFF/1.2 (once finalized)
+|Internal reference number of this OGC(R) document:    TBD
+|Version: 1.2-development
 |Category: OGC(R) Implementation Standard
-|Editors: Emmanuel Devys, Ted Habermann, Chuck Heazel, Roger Lott, Even Rouault
+|Editors: Joan Masó, Emmanuel Devys, Ted Habermann, Chuck Heazel, Roger Lott, Even Rouault
 |===
 
 [cols = "^", frame = "none"]
@@ -35,7 +35,7 @@
 [cols = "^", frame = "none", grid = "none"]
 |===
 |*Copyright notice*
-|Copyright (C) 2019 Open Geospatial Consortium
+|Copyright (C) 2019-2021 Open Geospatial Consortium
 |To obtain additional rights of use, visit http://www.opengeospatial.org/legal/
 |===
 


### PR DESCRIPTION
(As mentioned during 2021-08-31 meeting)