### PR TITLE
Move column for CoordinateEpochGeoKey

### DIFF
--- a/GeoTIFF_Standard/standard/annex-e.adoc
+++ b/GeoTIFF_Standard/standard/annex-e.adoc
@@ -254,7 +254,7 @@ __Table E.1 - Summary of GeoKey IDs and names __
 5+<| [underline]#Dynamic CRS Parameter Keys#
 ^| 5120
 ^| Double
-<| CoordinateEpochGeoKey
 <|
-<| (as GeoTIFF v1.2)
+<|
+<| CoordinateEpochGeoKey
 |====


### PR DESCRIPTION
In table E.1 (Summary of GeoKey IDs and names), move the `CoordinateEpochGeoKey` key name from the _"GeoTIFF v1.0 key name"_ column to the _"This document key name"_. In my understanding, that key didn't existed in GeoTIFF 1.0.

The columns are easier to see in the [rendered table](https://docs.ogc.org/is/19-008r4/19-008r4.html#_summary_of_geokey_ids_and_names). It is a minor formatting adjustment for #99.