### PR TITLE
Identify the celestial body in GeoTIFF

### DIFF
--- a/GeoTIFF_Standard/standard/abstract_tests/TIFF_Tests/TEST_Ascii_Param.adoc
+++ b/GeoTIFF_Standard/standard/abstract_tests/TIFF_Tests/TEST_Ascii_Param.adoc
@@ -13,6 +13,7 @@
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.ID
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.count
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys
+|http://www.opengis.net/spec/GeoTIFF/1.2/req/CelestialBodyGeoKey
 |===
 
 *Purpose:* Verify ASCII parameters
@@ -69,6 +70,7 @@
 ^| Requirements Class
 ^| 1026 <| CitationGeoKeys (GTCitationGeoKey)
 ^| 2049 <| CitationGeoKeys (GeodeticCitationGeoKey)
+^| 2063 <| CitationGeoKeys (CelestialBodyGeoKey)
 ^| 3073 <| CitationGeoKeys (ProjectedCitationGeoKey)
 ^| 4097 <| CitationGeoKeys (VerticalCitationGeoKey)
 |===

--- a/GeoTIFF_Standard/standard/abstract_tests/TIFF_Tests/TEST_Short_Param.adoc
+++ b/GeoTIFF_Standard/standard/abstract_tests/TIFF_Tests/TEST_Short_Param.adoc
@@ -15,8 +15,8 @@
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey
-|http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey
-|http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey
+|http://www.opengis.net/spec/GeoTIFF/1.2/req/GeodeticDatumGeoKey
+|http://www.opengis.net/spec/GeoTIFF/1.2/req/PrimeMeridianGeoKey
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey

--- a/GeoTIFF_Standard/standard/annex-b.adoc
+++ b/GeoTIFF_Standard/standard/annex-b.adoc
@@ -490,6 +490,8 @@ For a user-defined geographic 2D CRS the user is expected to provide:
 
 *** the geodetic datum name (through the _GeodeticCitationGeoKey_),
 
+*** if different than Earth, the celestial body name (through the _CelestialBodyGeoKey_),
+
 *** the ellipsoid (through the _EllipsoidGeoKey_, see <<User-defined ellipsoid>>), and
 
 *** the prime meridian (through the _PrimeMeridianGeoKey_, see <<User-defined prime meridian>>);
@@ -520,6 +522,8 @@ For a user-defined geocentric CRS the user is expected to provide:
 **  user-defined geodetic datum name and other defining information:
 
 *** the geodetic datum name (through the _GeodeticCitationGeoKey_),
+
+*** if different than Earth, the celestial body name (through the _CelestialBodyGeoKey_),
 
 *** the ellipsoid (through the _EllipsoidGeoKey_, see <<User-defined ellipsoid>>), and
 

--- a/GeoTIFF_Standard/standard/annex-b.adoc
+++ b/GeoTIFF_Standard/standard/annex-b.adoc
@@ -426,34 +426,52 @@ In GeoTIFF, standard CRSs are identified through reference to an EPSG CRS code.
 This is sufficient to define the CRS component objects.
 Further information on EPSG codes is given in <<Requirements for definition of Model CRS (when Model is from GeoTIFF CRS register)>>.
 
-NOTE: This document removes the reference to the specific EPSG codes listed in the 1995 GeoTIFF v1.0 specification and replaces it by *allowing reference to any code in the EPSG Dataset*, including codes for any objects introduced into the EPSG Dataset after publication of this document.
+NOTE: This document removes the reference to the specific EPSG codes listed in the 1995 GeoTIFF v1.0 specification
+and replaces it by *allowing reference to any code in the EPSG Dataset*,
+including codes for any objects introduced into the EPSG Dataset after publication of this document.
 
 ==== User-defined Model Coordinate Reference Systems
 GeoTIFF attempts to allow Model CRSs that are not described in the standard CRS register to be defined through user-defined keys.
 However the provisions made are limited in that:
 
-* no provision was made for fully describing coordinate system; although axis units could be described, provision for describing axis order and positive direction was omitted; and
+* no provision was made for fully describing coordinate system;
+  although axis units could be described, provision for describing axis order and positive direction was omitted;
+  and
 
-* there is ambiguity in the provision for describing user-defined map projections. Codes for some common map projection methods and map projection parameters were provided, but neither the method nor the parameter were defined. Inferences may be made from the listed map projection method names and map projection parameter names, but ambiguity remains so interoperability is not guaranteed.
+* there is ambiguity in the provision for describing user-defined map projections.
+  Codes for some common map projection methods and map projection parameters were provided,
+  but neither the method nor the parameter were defined.
+  Inferences may be made from the listed map projection method names and map projection parameter names,
+  but ambiguity remains so interoperability is not guaranteed.
 
 In practice, user-defined Model CRS definition is limited to the following cases.
 
-i)	A user-defined projected CRS which uses a base geographic CRS and a map projection that are both individually available from the GeoTIFF CRS register but, in the register, not associated together. EPSG geogCRS code needs citing through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.EPSG, EPSG projection code needs citing through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.EPSG
+i)   A user-defined projected CRS which uses a base geographic CRS and a map projection that are both
+     individually available from the GeoTIFF CRS register but, in the register, not associated together.
+     EPSG geogCRS code needs citing through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.EPSG,
+     EPSG projection code needs citing through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.EPSG.
 
-ii)	A user-defined projected CRS which uses a user-defined geographic CRS with a map projection that is available from the GeoTIFF CRS register.
-GeogCRS needs defining as in Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.userdefined, EPSG projection code needs citing through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.EPSG
+ii)  A user-defined projected CRS which uses a user-defined geographic CRS
+     with a map projection that is available from the GeoTIFF CRS register.
+     GeogCRS needs defining as in Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.userdefined,
+     EPSG projection code needs citing through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.EPSG.
 
-iii)	A user-defined geographic CRS available from the GeoTIFF CRS register and a map projection not in EPSG register. EPSG geogCRS code needs citing through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.EPSG, projection needs defining through Requirement http://www.opengis.net/spec/req/GeoTIFF/1.1/ProjectionGeoKey.userdefined using the v1.0 provisions (use the names in annex C).
+iii) A user-defined geographic CRS available from the GeoTIFF CRS register and a map projection not in EPSG register.
+     EPSG geogCRS code needs citing through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.EPSG,
+     projection needs defining through Requirement http://www.opengis.net/spec/req/GeoTIFF/1.1/ProjectionGeoKey.userdefined
+     using the v1.0 provisions (use the names in annex C).
 
- iv) Neither base GeogCRS or map projection is in EPSG. GeogCRS needs defining, projection needs defining through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.userdefined using the v1.0 provisions (the names in annex C).
+ iv) Neither base GeogCRS or map projection is in EPSG. GeogCRS needs defining,
+     projection needs defining through Requirement http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.userdefined
+     using the v1.0 provisions (the names in annex C).
 
 For the transformation from raster space to model space,
 some implicit convention is made about axis positive direction and axis order.
 It is assumed that:
 
-*	projected CRS axes are easting, northing;
+* projected CRS axes are easting, northing;
 
-*	geographic 2D CRS axes are longitude east, latitude north; and
+* geographic 2D CRS axes are longitude east, latitude north; and
 
 * vertical CRS axis is height up.
 
@@ -462,82 +480,88 @@ NOTE: Users must note that this GeoTIFF practice is not in line with ISO TC211 a
 ===== User-defined geographic 2D CRS
 For a user-defined geographic 2D CRS the user is expected to provide:
 
-*	geocentric coordinate reference system name (through the _GeodeticCitationGeoKey_);
+*   geocentric coordinate reference system name (through the _GeodeticCitationGeoKey_);
 
-*	geodetic datum through the _GeodeticDatumGeoKey_, either:
+*   geodetic datum through the _GeodeticDatumGeoKey_, either:
 
-**	the geodetic datum code (if available through standard EPSG code), or
+**  the geodetic datum code (if available through standard EPSG code), or
 
-**	user-defined geodetic datum name and other defining information:
+**  user-defined geodetic datum name and other defining information:
 
-***	the geodetic datum name (through the _GeodeticCitationGeoKey_),
+*** the geodetic datum name (through the _GeodeticCitationGeoKey_),
 
-***	the ellipsoid (through the _EllipsoidGeoKey_, see <<User-defined ellipsoid>>), and
+*** the ellipsoid (through the _EllipsoidGeoKey_, see <<User-defined ellipsoid>>), and
 
-***	the prime meridian (through the _PrimeMeridianGeoKey_, see <<User-defined prime meridian>>);
+*** the prime meridian (through the _PrimeMeridianGeoKey_, see <<User-defined prime meridian>>);
 
-*	axis unit through the _GeogAngularUnitsGeoKey_, either:
+*   axis unit through the _GeogAngularUnitsGeoKey_, either:
 
-**	angle unit code (if available through standard EPSG code), or
+**  angle unit code (if available through standard EPSG code), or
 
-**	user-defined angle unit name (through the _GeodeticCitationGeoKey_) and scaling from SI base unit of radian (through the _GeogAngularUnitSizeGeoKey_); and
+**  user-defined angle unit name (through the _GeodeticCitationGeoKey_) and
+    scaling from SI base unit of radian (through the _GeogAngularUnitSizeGeoKey_); and
 
-*	if the CRS uses a user-defined ellipsoid, the ellipsoid axis unit through the _GeogLinearUnitsGeoKey_, either:
+*   if the CRS uses a user-defined ellipsoid, the ellipsoid axis unit through the _GeogLinearUnitsGeoKey_, either:
 
-**	length unit code (if available through standard EPSG code), or
+**  length unit code (if available through standard EPSG code), or
 
-**	user-defined length unit name (through the _GeodeticCitationGeoKey_) and scaling from SI base unit of meter (through the _GeogLinearUnitSizeGeoKey_).
+**  user-defined length unit name (through the _GeodeticCitationGeoKey_) and
+    scaling from SI base unit of meter (through the _GeogLinearUnitSizeGeoKey_).
 
 ===== User-defined geocentric CRS
 For a user-defined geocentric CRS the user is expected to provide:
 
-*	geocentric coordinate reference system name (through the _GeodeticCitationGeoKey_);
+*   geocentric coordinate reference system name (through the _GeodeticCitationGeoKey_);
 
-*	geodetic datum through the _GeodeticDatumGeoKey_, either:
+*   geodetic datum through the _GeodeticDatumGeoKey_, either:
 
-**	the geodetic datum code (if available through standard EPSG code), or
+**  the geodetic datum code (if available through standard EPSG code), or
 
-**	user-defined geodetic datum name and other defining information:
+**  user-defined geodetic datum name and other defining information:
 
-***	the geodetic datum name (through the _GeodeticCitationGeoKey_),
+*** the geodetic datum name (through the _GeodeticCitationGeoKey_),
 
-***	the ellipsoid (through the _EllipsoidGeoKey_, see <<User-defined ellipsoid>>), and
+*** the ellipsoid (through the _EllipsoidGeoKey_, see <<User-defined ellipsoid>>), and
 
-***	the prime meridian (through the _PrimeMeridianGeoKey_, see <<User-defined prime meridian>>);
+*** the prime meridian (through the _PrimeMeridianGeoKey_, see <<User-defined prime meridian>>);
 
-*	axis unit through the _GeogLinearUnitsGeoKey_, either:
+*   axis unit through the _GeogLinearUnitsGeoKey_, either:
 
-**	length unit code (if available through standard EPSG code), or
+**  length unit code (if available through standard EPSG code), or
 
-**	user-defined length unit name (through the _GeodeticCitationGeoKey_) and scaling from SI base unit of meter (through the _GeogLinearUnitSizeGeoKey_); and
+**  user-defined length unit name (through the _GeodeticCitationGeoKey_) and
+    scaling from SI base unit of meter (through the _GeogLinearUnitSizeGeoKey_); and
 
-*	if the CRS uses a user-defined prime meridian, prime meridian Greenwich longitude unit through the _GeogAngularUnitsGeoKey_, either:
+*   if the CRS uses a user-defined prime meridian, prime meridian Greenwich longitude unit through the _GeogAngularUnitsGeoKey_, either:
 
-**	angle unit code (if available through standard EPSG code), or
+**  angle unit code (if available through standard EPSG code), or
 
-**	user-defined angle unit name (through the _GeodeticCitationGeoKey_) and scaling from SI base unit of radian (through the _GeogAngularUnitSizeGeoKey_).
+**  user-defined angle unit name (through the _GeodeticCitationGeoKey_) and
+    scaling from SI base unit of radian (through the _GeogAngularUnitSizeGeoKey_).
 
 ===== User-defined ellipsoid
 For any user-defined geocentric, geographic 3D or geographic 2D CRS an ellipsoid needs to be identified.
 The user is expected to provide:
 
-*	ellipsoid through the _EllipsoidGeoKey_, either:
+*   ellipsoid through the _EllipsoidGeoKey_, either:
 
-**	the ellipsoid code (if available through standard EPSG code), or
+**  the ellipsoid code (if available through standard EPSG code), or
 
-**	the user-defined ellipsoid name and other defining information:
+**  the user-defined ellipsoid name and other defining information:
 
-***	the ellipsoid name (through the _GeodeticCitationGeoKey_),
+*** the ellipsoid name (through the _GeodeticCitationGeoKey_),
 
-***	the ellipsoid semi-major axis (through the _EllipsoidSemiMajorAxisGeoKey_),
+*** the ellipsoid semi-major axis (through the _EllipsoidSemiMajorAxisGeoKey_),
 
-***	either the ellipsoid semi-minor axis (through the _EllipsoidSemiMinorAxisGeoKey_) or the ellipsoid inverse flattening (through the _EllipsoidInvFlatteningGeoKey_),
+*** either the ellipsoid semi-minor axis (through the _EllipsoidSemiMinorAxisGeoKey_) or
+    the ellipsoid inverse flattening (through the _EllipsoidInvFlatteningGeoKey_),
 
-***	The units for the ellipsoid axis or axes;
+*** The units for the ellipsoid axis or axes;
 
-*	For geocentric the ellipsoid axis or axes values must given in the length unit defined through the _GeogLinearUnitsGeoKey_ already required (see <<User-defined geocentric CRS>>); and
+*   For geocentric the ellipsoid axis or axes values must given in the length unit defined through
+    the _GeogLinearUnitsGeoKey_ already required (see <<User-defined geocentric CRS>>); and
 
-*	For geographic 2D CRSs, then a _GeogLinearUnitsGeoKey_ is additionally required.
+*   For geographic 2D CRSs, then a _GeogLinearUnitsGeoKey_ is additionally required.
 
 ===== User-defined prime meridian
 For any user-defined geocentric,
@@ -545,75 +569,84 @@ geographic 3D or geographic 2D CRS a prime meridian needs to be identified whene
 (If no prime meridian is identified, it should be assumed to be Greenwich).
 The user is expected to provide:
 
-*	Prime meridian through the _PrimeMeridianGeoKey_, either:
+*   prime meridian through the _PrimeMeridianGeoKey_, either:
 
-**	the prime meridian code (if available through standard EPSG code), or
+**  the prime meridian code (if available through standard EPSG code), or
 
-**	the user-defined prime meridian name and other defining information:
+**  the user-defined prime meridian name and other defining information:
 
-***	the prime meridian name (through the _GeodeticCitationGeoKey_),
+*** the prime meridian name (through the _GeodeticCitationGeoKey_),
 
-***	the prime meridian longitude (through the _PrimeMeridianLongitudeGeoKey_),
+*** the prime meridian longitude (through the _PrimeMeridianLongitudeGeoKey_),
 
-***	the units for the prime meridian longitude;
+*** the units for the prime meridian longitude;
 
-*	For geographic CRSs the prime meridian longitude value must given in the angle unit defined through the _GeogAngularUnitsGeoKey_ already required (see <<User-defined geographic 2D CRS>>); and
+*   For geographic CRSs the prime meridian longitude value must given in the angle unit defined
+    through the _GeogAngularUnitsGeoKey_ already required (see <<User-defined geographic 2D CRS>>); and
 
-*	For geocentric CRSs, then a _GeogAngularUnitsGeoKey_ is additionally required.
+*   For geocentric CRSs, then a _GeogAngularUnitsGeoKey_ is additionally required.
 
 ===== User-defined Projected Coordinate Reference Systems
 For a user-defined projected CRS the user is expected to provide:
 
-*	projected coordinate reference system name (through _ProjectedCitationGeoKey_);
+*   projected coordinate reference system name (through _ProjectedCitationGeoKey_);
 
-*	base geographic CRS (either standard EPSG code or user-defined, see <<User-defined geographic 2D CRS>>);
+*   base geographic CRS (either standard EPSG code or user-defined, see <<User-defined geographic 2D CRS>>);
 
-*	map projection through the _ProjectionGeoKey_, either:
+*   map projection through the _ProjectionGeoKey_, either:
 
-**	map projection code (if available through standard EPSG code), or
+**  map projection code (if available through standard EPSG code), or
 
-**	user-defined map projection (see below); and
+**  user-defined map projection (see below); and
 
-*	axis unit through _ProjLinearUnitsGeoKey_, either:
+*   axis unit through _ProjLinearUnitsGeoKey_, either:
 
-**	length unit code (if available through standard EPSG code), or
+**  length unit code (if available through standard EPSG code), or
 
-**	user-defined length unit name (through the _ProjectedCitationGeoKey_) and scaling from SI base unit of meter (through the _ProjLinearUnitSizeGeoKey_).
+**  user-defined length unit name (through the _ProjectedCitationGeoKey_) and
+    scaling from SI base unit of meter (through the _ProjLinearUnitSizeGeoKey_).
 
 ===== User-defined map projection
 For a user-defined map projection the user is expected to provide:
 
-*	map projection name (through _ProjectedCitationGeoKey_);
+*   map projection name (through _ProjectedCitationGeoKey_);
 
-*	map projection method (through _ProjMethodGeoKey_);
+*   map projection method (through _ProjMethodGeoKey_);
 
-*	map projection parameter values (using a set of keys appropriate to the map projection method):
+*   map projection parameter values (using a set of keys appropriate to the map projection method):
 
-**	For map projection parameters that are lengths the parameter value needs to be expressed in the units defined through the _ProjLinearUnitsGeoKey_, and
+**  For map projection parameters that are lengths the parameter value needs
+    to be expressed in the units defined through the _ProjLinearUnitsGeoKey_, and
 
-**	For map projection parameters that are angles the parameter value needs to be expressed in the units defined through the _GeogAngularUnitsGeoKey_, which is required in the base geographic CRS description, except for azimuths when the value needs to be expressed in the units defined through a _GeogAzimuthUnitsGeoKey_; and
+**  For map projection parameters that are angles the parameter value needs to be expressed in the units
+    defined through the _GeogAngularUnitsGeoKey_, which is required in the base geographic CRS description,
+    except for azimuths when the value needs to be expressed in the units defined through a _GeogAzimuthUnitsGeoKey_;
+    and
 
-*	if the map projection method requires a parameter that is an azimuth, the azimuth unit through a _GeogAzimuthUnitsGeoKey_.
+*   if the map projection method requires a parameter that is an azimuth,
+    the azimuth unit through a _GeogAzimuthUnitsGeoKey_.
 
 ===== User-defined Vertical Coordinate Reference Systems
 For a user-defined vertical CRS the user is expected to provide:
 
-* vertical coordinate reference system name (through _VerticalCitationGeoKey_);
+*   vertical coordinate reference system name (through _VerticalCitationGeoKey_);
 
-*	user-defined vertical datum through _VerticalDatumGeoKey_, either:
+*   user-defined vertical datum through _VerticalDatumGeoKey_, either:
 
-**	the vertical datum code (if available through standard EPSG code), or
+**  the vertical datum code (if available through standard EPSG code), or
 
-**	the vertical datum name and other defining information (through the _VerticalCitationGeoKey_); and
+**  the vertical datum name and other defining information (through the _VerticalCitationGeoKey_); and
 
-*	vertical axis unit through _VerticalUnitsGeoKey_, either:
+*   vertical axis unit through _VerticalUnitsGeoKey_, either:
 
-**	linear unit code (if available through standard EPSG code), or
+**  linear unit code (if available through standard EPSG code), or
 
-**	linear unit name (through _VerticalCitationGeoKey_) and scaling from SI base unit of meter (through _GeogLinearUnitSizeGeoKey_).
+**  linear unit name (through _VerticalCitationGeoKey_) and
+    scaling from SI base unit of meter (through _GeogLinearUnitSizeGeoKey_).
 
 === Model CRS Reference Parameters
-Most of the GeoTIFF standard definitions for model ('real world') coordinate reference systems and their component elements are based on the hierarchical system developed for the EPSG Geodetic Parameter Dataset ('EPSG Dataset').
+Most of the GeoTIFF standard definitions for model ('real world') coordinate reference systems and their component
+elements are based on the hierarchical system developed for the EPSG Geodetic Parameter Dataset ('EPSG Dataset').
 The complete set of EPSG definitions is available at http://www.epsg-registry.org.
 
 The EPSG Dataset is maintained by the Geodesy Subcommittee of the International Association of Oil and Gas Producers (IOGP).
@@ -623,8 +656,7 @@ Some of these objects themselves are composed objects and attributes, in a neste
 Each release of new or revised data is indicated by the EPSG Dataset version number.
 Since 1999 (from EPSG Dataset v5.0 and later) EPSG policy has been to never remove any invalid data but instead to leave it in the Dataset with its status set to deprecated.
 Deprecated data contains a significant error (significant defined as having impact on the result of applying a transformation or conversion) and is invalid.
-As such,
-since 1999 reference to the version of the EPSG Dataset to qualify codes of entities within the Dataset has been unnecessary.
+As such, since 1999 reference to the version of the EPSG Dataset to qualify codes of entities within the Dataset has been unnecessary.
 Using EPSG Dataset versions 5.0 and 9.3 as examples, urn:ogc:def:crs:EPSG:5.0:4326 and urn:ogc:def:crs:EPSG:9.3:4326 and urn:ogc:def:crs:EPSG::4326 reference the same object.
 The terms of use of the EPSG Dataset are given at http://www.epsg.org/Termsofuse.aspx.
 
@@ -632,11 +664,23 @@ The terms of use of the EPSG Dataset are given at http://www.epsg.org/Termsofuse
 Within the EPSG Dataset each object has a code.
 There have been three generations of coding.
 
-i)	In v1.x of the publicly-available EPSG Dataset (1994-1996, published by the Petrotechnical Open Software Corporation, POSC), codes were alphanumeric. The initial letter indicated the object type, and objects within each type were then assigned sequential numbers.
+i)   In v1.x of the publicly-available EPSG Dataset (1994-1996, published by the Petrotechnical Open Software Corporation, POSC), codes were alphanumeric.
+     The initial letter indicated the object type, and objects within each type were then assigned sequential numbers.
 
-ii)	With the introduction of GeoTIFF v1.0, EPSG Dataset v2.1 object codes were changed to integer values in the range 1024 through 32766. This overall code range was divided into non-overlapping sub-ranges, with one sub-range range for each object type. At that time, all EPSG object codes were unique. The GeoTIFF v1.0 specification was written at this time, and the EPSG code ranges for object types were written into the GeoTIFF v1.0 specification.
+ii)  With the introduction of GeoTIFF v1.0, EPSG Dataset v2.1 object codes were changed to integer values in the range 1024 through 32766.
+     This overall code range was divided into non-overlapping sub-ranges, with one sub-range range for each object type.
+     At that time, all EPSG object codes were unique. The GeoTIFF v1.0 specification was written at this time,
+     and the EPSG code ranges for object types were written into the GeoTIFF v1.0 specification.
 
-iii)	However as the number of items in the EPSG Dataset grew, some of the object code sub-ranges became fully assigned. The unique code system broke down. Since 2006, all object types have been separately assigned codes within the range 1024 through 32766. Within each object type codes remain unique, but one code value may be used for several object types. For example, code 4326 is used for both a CRS and for a geographic extent (in EPSG called 'area'). Codes at and just above the lower end of the range 1024 through 32766 may be used by numerous object types: for example by the year 2018 code 1026 has been assigned to 10 different object types. EPSG codes therefore are only unique when the object type is disclosed. urn:ogc:def:EPSG::4326 is ambiguous, urn:ogc:def:crs:EPSG::4326 and urn:ogc:def:area:EPSG::4326 are unambiguous.
+iii) However as the number of items in the EPSG Dataset grew, some of the object code sub-ranges became fully assigned.
+     The unique code system broke down.
+     Since 2006, all object types have been separately assigned codes within the range 1024 through 32766.
+     Within each object type codes remain unique, but one code value may be used for several object types.
+     For example, code 4326 is used for both a CRS and for a geographic extent (in EPSG called 'area').
+     Codes at and just above the lower end of the range 1024 through 32766 may be used by numerous object types:
+     for example by the year 2018 code 1026 has been assigned to 10 different object types.
+     EPSG codes therefore are only unique when the object type is disclosed.
+     urn:ogc:def:EPSG::4326 is ambiguous, urn:ogc:def:crs:EPSG::4326 and urn:ogc:def:area:EPSG::4326 are unambiguous.
 
 The GeoTIFF v1.0 specification refers to "obsolete EPSG/POSC codes." These refer to the numeric part of the alphanumeric coding in (i) above.
 These values had been used in some GeoTIFF v0.x files and for backward compatibility with those earlier files GeoTIFF v1.0 retained references to them.
@@ -644,7 +688,8 @@ As all of these alphanumeric codes were changed to the integer coding in (ii) ab
 reference to these obsolete codes should now be unnecessary.
 In effect, for model CRS GeoKeys the obsolete code range may be treated as a reserved code range.
 
-Note: 'EPSG/POSC obsolete codes' refers specifically to the coding in generation (i) above, and should not be confused with codes from generations (ii) and (iii) which have been given the status of 'deprecated.'
+Note: 'EPSG/POSC obsolete codes' refers specifically to the coding in generation (i) above,
+and should not be confused with codes from generations (ii) and (iii) which have been given the status of 'deprecated.'
 
 A reference to an EPSG coordinate reference system code is sufficient for a complete definition:
 it implies use of the CRS components (datum, ellipsoid, map projection,

--- a/GeoTIFF_Standard/standard/annex-e.adoc
+++ b/GeoTIFF_Standard/standard/annex-e.adoc
@@ -99,6 +99,11 @@ __Table E.1 - Summary of GeoKey IDs and names __
 <| Reserved (GeogTOWGS84GeoKey used by GDAL)
 <|
 <| Reserved
+^| 2063
+^| Ascii
+<|
+<|
+<| CelestialBodyGeoKey
 5+<| [underline]#Projected CRS Parameter Keys#
 ^| [underline]#_2060_#
 ^| Short

--- a/GeoTIFF_Standard/standard/annex-e.adoc
+++ b/GeoTIFF_Standard/standard/annex-e.adoc
@@ -254,7 +254,7 @@ __Table E.1 - Summary of GeoKey IDs and names __
 5+<| [underline]#Dynamic CRS Parameter Keys#
 ^| 5120
 ^| Double
-<| CoordinateEpochGeoKey
 <|
-<| (as GeoTIFF v1.2)
+<|
+<| CoordinateEpochGeoKey
 |====

--- a/GeoTIFF_Standard/standard/clause_7_requirements.adoc
+++ b/GeoTIFF_Standard/standard/clause_7_requirements.adoc
@@ -99,15 +99,15 @@ include::requirements/Configuration_Keys/requirements_class_GTRasterTypeGeoKey.a
 
 This GeoKey defines the type of Model coordinate reference system used, to which the transformation from the raster space is made:
 
-*	Model CRS is unknown or unspecified;
+* Model CRS is unknown or unspecified;
 
-*	Model CRS is a Geographic 2D CRS;
+* Model CRS is a Geographic 2D CRS;
 
-*	Model CRS is a Geocentric CRS;
+* Model CRS is a Geocentric CRS;
 
 * Model CRS is a Projected CRS; and
 
-*	Model CRS is user-defined.
+* Model CRS is user-defined.
 
 If the Model coordinate reference system is from the GeoTIFF standard CRS register (i.e., EPSG register),
 then only the registered CRS code need be specified.
@@ -117,13 +117,15 @@ If the Model coordinate reference system is not from the GeoTIFF standard CRS re
 then it requires the specification of some or all CRS elements.
 See <<Requirements for definition of user-defined Model CRS>>.
 
-The GeoTIFF v1.0 format has also been used to describe pseudo-3D compound CRSs consisting of a projected CRS and a vertical CRS or a geographic 2D CRS and a vertical CRS,
+The GeoTIFF v1.0 format has also been used to describe pseudo-3D compound CRSs
+consisting of a projected CRS and a vertical CRS or a geographic 2D CRS and a vertical CRS,
 as well as a geographic 3D CRS.
 In this document, this usage is permitted but not explicitly described through the GTModelTypeGeoKey.
 Recommendations are given in Annex D.
 
 include::requirements/Configuration_Keys/requirements_class_GTModelTypeGeoKey.adoc[]
-NOTE: The GTCitationGeoKey is also provided to give an ASCII reference to published documentation on the overall configuration of the GeoTIFF file (see <<Requirements Class Citation GeoKeys>>).
+NOTE: The GTCitationGeoKey is also provided to give an ASCII reference to published documentation
+on the overall configuration of the GeoTIFF file (see <<Requirements Class Citation GeoKeys>>).
 
 === Raster to Model Coordinate Transformation Requirements
 
@@ -190,7 +192,8 @@ include::requirements/Vertical_GeoKeys/requirements_class_VerticalGeoKey.adoc[]
 The _GTCitationGeoKey_ is provided to give an ASCII reference to published documentation on the overall configuration of the GeoTIFF file.
 The _GeodeticCitationGeoKey_,
 _ProjectedCitationGeoKey_ and _VerticalCitationGeoKey_ are used to describe Model CRS elements through ASCII free text.
-A citation may be included with a CRS identified through the GeoTIFF CRS register (<<Requirements for definition of Model CRS (when Model CRS is from GeoTIFF CRS register)>>).
+A citation may be included with a CRS identified through the GeoTIFF CRS register
+(<<Requirements for definition of Model CRS (when Model CRS is from GeoTIFF CRS register)>>).
 A citation is mandatory for a user-defined CRSs and CRS objects (<<Requirements for definition of user-defined Model CRS>>).
 The _GeodeticCitationGeoKey_, _ProjectedCitationGeoKey_ and _VerticalCitationGeoKey_ are used with CRSs and CRS components.
 
@@ -200,40 +203,47 @@ include::requirements/Citation_Keys/requirements_class_CitationGeoKeys.adoc[]
 
 === Requirements for definition of user-defined Model CRS
 
-The GeoKeys described in this section are needed only when Model CRSs are not available from the GeoTIFF CRS register and the CRS or one or more of its component objects is user-defined,
+The GeoKeys described in this section are needed only when Model CRSs are not available
+from the GeoTIFF CRS register and the CRS or one or more of its component objects is user-defined,
 that is if one or more of ProjectedCRSGeoKey, GeodeticCRSGeoKey, or VerticalGeoKey has a value of 32767.
 
 NOTE: Anyone not interested in constructing a user-defined model CRS can ignore this section.
 
-NOTE: It should be noted that the implicit axis order of user-defined CRS definitions is fixed at (lon,lat,height) in case of geographic and (east,north,height) in case of projected regardless of the model space CRS definition. This convention was implicit in GeoTIFF 1.0 and still is valid in this revision. As with GeoTIFF 1.0, it is not possible to express a user-defined CRS that deviates from this axis order convention. The intention is to address this limitation in a future revision.
+NOTE: It should be noted that the implicit axis order of user-defined CRS definitions is fixed at (lon,lat,height)
+in case of geographic and (east,north,height) in case of projected regardless of the model space CRS definition.
+This convention was implicit in GeoTIFF 1.0 and still is valid in this revision.
+As with GeoTIFF 1.0, it is not possible to express a user-defined CRS that deviates from this axis order convention.
+The intention is to address this limitation in a future revision.
 
 ==== Requirements Class Units GeoKeys
 
-These keys are used to specify Units of Measure (UoM) through the identification of a unit from the GeoTIFF CRS register or to indicate that the unit is user-defined.
+These keys are used to specify Units of Measure (UoM) through the identification of a unit from the GeoTIFF CRS register
+or to indicate that the unit is user-defined.
 
 The *GeogAngularUnitsGeoKey* key is used to specify the angular unit for:
 
-*	the axes in user-defined geographic 2D CRSs;
-*	the horizontal axes in user-defined geographic 3D CRSs;
-*	the longitude from the reference meridian in user-defined prime meridians; and
-*	user-defined map projection parameters that are angles.
+* the axes in user-defined geographic 2D CRSs;
+* the horizontal axes in user-defined geographic 3D CRSs;
+* the longitude from the reference meridian in user-defined prime meridians; and
+* user-defined map projection parameters that are angles.
 
-The *GeogAzimuthUnitsGeoKey* key is used to specify the angular unit for user-defined map projection parameters when these differ from the angular unit described through the GeogAngularUnitsGeoKey.
+The *GeogAzimuthUnitsGeoKey* key is used to specify the angular unit for user-defined map projection parameters
+when these differ from the angular unit described through the GeogAngularUnitsGeoKey.
 
 The *GeogLinearUnitsGeoKey* key is used to specify the linear unit for:
 
 * the axes in user-defined geocentric Cartesian CRSs;
-*	the height axis of a user-defined geographic 3D CRS; and
-*	for user-defined ellipsoid axes.
+* the height axis of a user-defined geographic 3D CRS; and
+* for user-defined ellipsoid axes.
 
 The *ProjLinearUnitsGeoKey* key is used to specify the linear units for:
 
-*	the axes of  a user-defined projected CRS; and
-*	map projection parameters that are lengths.
+* the axes of  a user-defined projected CRS; and
+* map projection parameters that are lengths.
 
 The *VerticalUnitsGeoKey* key is used to specify the linear unit for:
 
-*	the axis of a user-defined vertical CRS.
+* the axis of a user-defined vertical CRS.
 
 include::requirements/Units_Keys/requirements_class_UnitsGeoKeys.adoc[]
 

--- a/GeoTIFF_Standard/standard/requirements/Configuration_Keys/requirements_class_GTModelTypeGeoKey.adoc
+++ b/GeoTIFF_Standard/standard/requirements/Configuration_Keys/requirements_class_GTModelTypeGeoKey.adoc
@@ -23,15 +23,15 @@ _The GTModelTypeGeoKey SHALL have type = SHORT_
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.value +
 _The GTModelTypeGeoKey value SHALL be:_
 
-*	0 to indicate that the Model CRS in undefined or unknown; or
+* 0 to indicate that the Model CRS in undefined or unknown; or
 
-*	1 to indicate that the Model CRS is a 2D projected coordinate reference system, indicated by the value of the ProjectedCRSGeoKey; or
+* 1 to indicate that the Model CRS is a 2D projected coordinate reference system, indicated by the value of the ProjectedCRSGeoKey; or
 
-*	2 to indicate that the Model CRS is a geographic 2D coordinate reference system, indicated by the value of the GeodeticCRSGeoKey; or
+* 2 to indicate that the Model CRS is a geographic 2D coordinate reference system, indicated by the value of the GeodeticCRSGeoKey; or
 
-*	3 to indicate that the Model CRS is a geocentric Cartesian 3D coordinate reference system, indicated by the value of the GeodeticCRSGeoKey; or
+* 3 to indicate that the Model CRS is a geocentric Cartesian 3D coordinate reference system, indicated by the value of the GeodeticCRSGeoKey; or
 
-*	32767 to indicate that the Model CRS type is user-defined.
+* 32767 to indicate that the Model CRS type is user-defined.
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 8.5 {set:cellbgcolor:#CACCCE}

--- a/GeoTIFF_Standard/standard/requirements/Geodetic_CRS_GeoKeys/requirements_class_CelestialBodyGeoKey.adoc
+++ b/GeoTIFF_Standard/standard/requirements/Geodetic_CRS_GeoKeys/requirements_class_CelestialBodyGeoKey.adoc
@@ -1,0 +1,16 @@
+[cols="1,4",width="90%"]
+|===
+2+|*Requirements Class TBD.0: CelestialBodyGeoKey* {set:cellbgcolor:#CACCCE}
+2+|http://www.opengis.net/spec/GeoTIFF/1.2/req/CelestialBodyGeoKey
+{set:cellbgcolor:#FFFFFF}
+
+|Requirement TBD.1 {set:cellbgcolor:#CACCCE}
+|http://www.opengis.net/spec/GeoTIFF/1.2/req/CelestialBodyGeoKey.ID +
+_The CelestialBodyGeoKey SHALL have ID = 2063_
+{set:cellbgcolor:#FFFFFF}
+
+|Requirement TBD.2 {set:cellbgcolor:#CACCCE}
+|http://www.opengis.net/spec/GeoTIFF/1.2/req/CelestialBodyGeoKey.type +
+_The CelestialBodyGeoKey SHALL have type = ASCII_
+{set:cellbgcolor:#FFFFFF}
+|===

--- a/GeoTIFF_Standard/standard/requirements/Geodetic_CRS_GeoKeys/requirements_class_GeodeticDatumGeoKey.adoc
+++ b/GeoTIFF_Standard/standard/requirements/Geodetic_CRS_GeoKeys/requirements_class_GeodeticDatumGeoKey.adoc
@@ -1,7 +1,7 @@
 [cols="1,4",width="90%"]
 |===
 2+|*Requirements Class 18.0: GeodeticDatumGeoKey* {set:cellbgcolor:#CACCCE}
-2+|http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey
+2+|http://www.opengis.net/spec/GeoTIFF/1.2/req/GeodeticDatumGeoKey
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 18.1 {set:cellbgcolor:#CACCCE}
@@ -29,8 +29,9 @@ NOTE: In GeoTIFF v1.0 the range was 6000-6999. Several values in this range have
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 18.5 {set:cellbgcolor:#CACCCE}
-|http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.userdefined +
-_If the GeodeticDatumGeoKey value is 32767 (User-Defined) then the GeodeticCitationGeoKey, PrimeMeridianGeoKey and EllipsoidGeoKey SHALL be populated._
+|http://www.opengis.net/spec/GeoTIFF/1.2/req/GeodeticDatumGeoKey.userdefined +
+_If the GeodeticDatumGeoKey value is 32767 (User-Defined) then the GeodeticCitationGeoKey, PrimeMeridianGeoKey and EllipsoidGeoKey SHALL be populated
+and the CelestialBodyGeoKey SHOULD be populated if different than Earth._
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 18.6 {set:cellbgcolor:#CACCCE}

--- a/GeoTIFF_Standard/standard/requirements/Geodetic_CRS_GeoKeys/requirements_class_PrimeMeridianGeoKey.adoc
+++ b/GeoTIFF_Standard/standard/requirements/Geodetic_CRS_GeoKeys/requirements_class_PrimeMeridianGeoKey.adoc
@@ -1,7 +1,7 @@
 [cols="1,4",width="90%"]
 |===
 2+|*Requirements Class 19.0: PrimeMeridianGeoKey* {set:cellbgcolor:#CACCCE}
-2+|http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey
+2+|http://www.opengis.net/spec/GeoTIFF/1.2/req/PrimeMeridianGeoKey
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 19.1 {set:cellbgcolor:#CACCCE}
@@ -29,8 +29,8 @@ NOTE: In GeoTIFF v1.0 the range was 8000-8999
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 19.5 {set:cellbgcolor:#CACCCE}
-|http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.userdefined +
-_If the PrimeMeridianGeoKey value is 32767 (User-Defined) then the GeodeticCitationGeoKey, and PrimeMeridianLongGeoKey SHALL be populated_
+|http://www.opengis.net/spec/GeoTIFF/1.2/req/PrimeMeridianGeoKey.userdefined +
+_If the PrimeMeridianGeoKey value is 32767 (User-Defined) then the GeodeticCitationGeoKey and PrimeMeridianLongGeoKey SHALL be populated_
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 19.6 {set:cellbgcolor:#CACCCE}

--- a/GeoTIFF_Standard/standard/requirements/Units_Keys/requirements_class_UnitsGeoKeys.adoc
+++ b/GeoTIFF_Standard/standard/requirements/Units_Keys/requirements_class_UnitsGeoKeys.adoc
@@ -19,54 +19,65 @@ _The VerticalUnitsGeoKey SHALL have ID = 4099_
 
 |Requirement 16.2 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.type +
-_The GeogAngularUnitsGeoKey, the GeogAzimuthUnitsGeoKey, the GeogLinearUnitsGeoKey, the ProjLinearUnitsGeoKey and the VerticalUnitsGeoKey SHALL each have type = SHORT_
+_The GeogAngularUnitsGeoKey, the GeogAzimuthUnitsGeoKey, the GeogLinearUnitsGeoKey, the ProjLinearUnitsGeoKey and the VerticalUnitsGeoKey
+SHALL each have type = SHORT_
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 16.3 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.reserved +
-_GeogAngularUnitsGeoKey, GeogAzimuthUnitsGeoKey, GeogLinearUnitsGeoKey, ProjLinearUnitsGeoKey and VerticalUnitsGeoKey values in the range 1-1023 SHALL be reserved._
+_GeogAngularUnitsGeoKey, GeogAzimuthUnitsGeoKey, GeogLinearUnitsGeoKey, ProjLinearUnitsGeoKey and VerticalUnitsGeoKey
+values in the range 1-1023 SHALL be reserved._
 
 NOTE: In GeoTIFF v1.0 the range 0001-2000 was used for obsolete GeoTIFF codes.
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 16.4 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.angular +
-_GeogAngularUnitsGeoKey and GeogAzimuthUnitsGeoKey values in the range 1024-32766 SHALL be EPSG Unit Of Measure (UOM) codes with type = angle._
+_GeogAngularUnitsGeoKey and GeogAzimuthUnitsGeoKey
+values in the range 1024-32766 SHALL be EPSG Unit Of Measure (UOM) codes with type = angle._
 
 NOTE: In GeoTIFF v1.0 the range was 9100-9199
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 16.5 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.linear +
-_GeogLinearUnitsGeoKey, ProjLinearUnitsGeoKey and VerticalUnitsGeoKey values in the range 1024-32766 SHALL be EPSG Unit Of Measure (UOM) codes with type = length._
+_GeogLinearUnitsGeoKey, ProjLinearUnitsGeoKey and VerticalUnitsGeoKey
+values in the range 1024-32766 SHALL be EPSG Unit Of Measure (UOM) codes with type = length._
 
-NOTE: In GeoTIFF v1.0 the range was 9000-9099. Several values in this range have been deprecated or deleted from the EPSG Dataset and should no longer be used. See <<annex-g.adoc#deprecated_units_codes,Table G.3 - Deprecated and deleted EPSG Unit of Measure codes>>
+NOTE: In GeoTIFF v1.0 the range was 9000-9099.
+Several values in this range have been deprecated or deleted from the EPSG Dataset and should no longer be used.
+See <<annex-g.adoc#deprecated_units_codes,Table G.3 - Deprecated and deleted EPSG Unit of Measure codes>>
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 16.6 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedAngular +
-_A GeogAngularUnitsGeoKey or a GeogAzimuthUnitsGeoKey value of 32767 SHALL be a user-defined angular unit.  If the value is 32767 (User-Defined) then the GeodeticCitationGeoKey and the GeogAngularUnitSizeGeoKey SHALL be populated_
+_A GeogAngularUnitsGeoKey or a GeogAzimuthUnitsGeoKey value of 32767 SHALL be a user-defined angular unit.
+If the value is 32767 (User-Defined) then the GeodeticCitationGeoKey and the GeogAngularUnitSizeGeoKey SHALL be populated_
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 16.7 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedGeogLinear +
-_A GeogLinearUnitsGeoKey value of 32767 SHALL be a user-defined linear unit. If the value is 32767 (User-Defined) then the GeodeticCitationGeoKey and the GeogLinearUnitSizeGeoKey SHALL be populated_
+_A GeogLinearUnitsGeoKey value of 32767 SHALL be a user-defined linear unit.
+If the value is 32767 (User-Defined) then the GeodeticCitationGeoKey and the GeogLinearUnitSizeGeoKey SHALL be populated_
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 16.8 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedProjLinear +
-_A ProjLinearUnitsGeoKey value of 32767 SHALL be a user-defined linear unit. If the value is 32767 (User-Defined) then the ProjectedCitationGeoKey and the ProjLinearUnitSizeGeoKey SHALL be populated._
+_A ProjLinearUnitsGeoKey value of 32767 SHALL be a user-defined linear unit.
+If the value is 32767 (User-Defined) then the ProjectedCitationGeoKey and the ProjLinearUnitSizeGeoKey SHALL be populated._
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 16.9 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedVertical +
 _A VerticalUnitsGeoKey value of 32767 (user defined) SHALL not be used_
 
-NOTE: The rationale for this is that it would require a VerticalUnitSizeGeoKey, which does not exist in GeoTIFF 1.0. For vertical units, this document supports only EPSG linear units.
+NOTE: The rationale for this is that it would require a VerticalUnitSizeGeoKey, which does not exist in GeoTIFF 1.0.
+For vertical units, this document supports only EPSG linear units.
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 16.10 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.private +
-_GeogAngularUnitsGeoKey, GeogAzimuthUnitsGeoKey, GeogLinearUnitsGeoKey, ProjLinearUnitsGeoKey and VerticalUnitsGeoKey values in the range 32768-65535 SHALL be private._
+_GeogAngularUnitsGeoKey, GeogAzimuthUnitsGeoKey, GeogLinearUnitsGeoKey, ProjLinearUnitsGeoKey and VerticalUnitsGeoKey
+values in the range 32768-65535 SHALL be private._
 {set:cellbgcolor:#FFFFFF}
 |===


### PR DESCRIPTION
Defines a new GeoKey for identifying the celestial body (Mars, Venus, _etc._) in a GeoTIFF file. It would be used in [User-defined Model Coordinate Reference Systems](http://docs.opengeospatial.org/is/19-008r4/19-008r4.html#_defining_model_coordinate_reference_systems). Some sections from GeoTIFF specification to edit are:

* [User-defined geographic 2D CRS](http://docs.opengeospatial.org/is/19-008r4/19-008r4.html#_user_defined_geographic_2d_crs)
* [User-defined geocentric CRS](http://docs.opengeospatial.org/is/19-008r4/19-008r4.html#_user_defined_geocentric_crs)

In particular the following list of items should be updated with the item given in italic characters:

* user-defined geodetic datum name and other defining information:
  * the geodetic datum name (through the `GeodeticCitationGeoKey`),
  * _the celestial body name (through the `CelestialBodyGeoKey`)_,

`CelestialBodyGeoKey` would be optional. If omitted, default value would be "Earth".

Proposed numerical value for `CelestialBodyGeoKey` is 2063.
