### PR TITLE
Projection parameters should be a ProjectionGeoKey requirement

### DIFF
--- a/GeoTIFF_Standard/Detailed Test Suite/abstract_tests/Projection_Definition_GeoKeys/TEST_ProjectionGeoKey.adoc
+++ b/GeoTIFF_Standard/Detailed Test Suite/abstract_tests/Projection_Definition_GeoKeys/TEST_ProjectionGeoKey.adoc
@@ -37,6 +37,7 @@
 
     A value of 32767 is valid (User-defined)
 
-    IF value = 32767 THEN verify that there is a ProjectedCitationGeoKey (GeoKey 3073), ProjectionMethodGeoKey (GeoKey 3075) and ProjLinearUnitsGeoKey (GeoKey 3076) in the GeoTIFF file.
+    IF value = 32767 THEN verify that there is a ProjectedCitationGeoKey (GeoKey 3073), ProjMethodGeoKey (GeoKey 3075), ProjLinearUnitsGeoKey (GeoKey 3076)
+    and keys for each map projection parameter (coordinate operation parameter) appropriate to that method in the GeoTIFF file.
 
     Values of 32768 through 65535 are valid (private)

--- a/GeoTIFF_Standard/Detailed Test Suite/abstract_tests/Requirements_Trace_Matrix.adoc
+++ b/GeoTIFF_Standard/Detailed Test Suite/abstract_tests/Requirements_Trace_Matrix.adoc
@@ -184,14 +184,13 @@
 | The ProjectionGeoKey SHALL have type = SHORT |TIFF_Test/ShortParameters, Projection_Definition_GeoKey/ProjectionGeoKey
 | ProjectionGeoKey values in the range 1-1023 SHALL be reserved |Projection_Definition_GeoKey/ProjectionGeoKey
 | ProjectionGeoKey values in the range 1024-32766 SHALL be valid EPSG map projection (coordinate operation) codes |Projection_Definition_GeoKey/ProjectionGeoKey
-| If the ProjectionGeoKey value is 32767 (User-Defined) then the ProjectedCitationGeoKey, ProjectionMethodGeoKey, and ProjLinearUnitsGeoKey SHALL be populated |Projection_Definition_GeoKey/ProjectionGeoKey
+| If the ProjectionGeoKey value is 32767 (User-Defined) then the ProjectedCitationGeoKey, ProjMethodGeoKey, ProjLinearUnitsGeoKey and keys for each map projection parameter (coordinate operation parameter) appropriate to that method SHALL be populated |Projection_Definition_GeoKey/ProjectionGeoKey
 | ProjectionGeoKey values in the range 32768-65535 SHALL be private |Projection_Definition_GeoKey/ProjectionGeoKey
 ^| *requirements_class_ProjMethodGeoKey* |
 | The ProjMethodGeoKey SHALL have ID = 3075 |TIFF_Test/ShortParameters, Projection_Definition_GeoKey/ProjMethodGeoKey
 | The ProjMethodGeoKey SHALL have type = SHORT |TIFF_Test/ShortParameters, Projection_Definition_GeoKey/ProjMethodGeoKey
 | ProjMethodGeoKey values in the range 1-27 SHALL be GeoTIFF map projection method codes |Projection_Definition_GeoKey/ProjMethodGeoKey
 | ProjMethodGeoKey values in the range 28-32766 SHALL be reserved |Projection_Definition_GeoKey/ProjMethodGeoKey
-| If the ProjectionMethodGeoKey value is 32767 (User-Defined) then the ProjectedCitationGeoKey and keys for each map projection parameter (coordinate operation parameter) appropriate to that method SHALL be populated. |Projection_Definition_GeoKey/ProjMethodGeoKey
 | ProjMethodGeoKey values in the range 32768-65535 SHALL be private |Projection_Definition_GeoKey/ProjMethodGeoKey
 ^| *requirements_class_ProjAngularParameters* |
 | The ProjStdParallel1GeoKey SHALL have ID = 3078 |TIFF_Test/DoubleParameters, Projection_Definition_GeoKeys/ProjAngularParameters

--- a/GeoTIFF_Standard/standard/requirements/Projection_Definition_Keys/requirements_class_ProjMethodGeoKey.adoc
+++ b/GeoTIFF_Standard/standard/requirements/Projection_Definition_Keys/requirements_class_ProjMethodGeoKey.adoc
@@ -28,7 +28,7 @@ _ProjMethodGeoKey values in the range 28-32766 SHALL be reserved_
 
 |Requirement 27.5 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.userdefined +
-_If the ProjectionMethodGeoKey value is 32767 (User-Defined) then the ProjectedCitationGeoKey and keys for each map projection parameter (coordinate operation parameter) appropriate to that method SHALL be populated._
+_The ProjMethodGeoKey value SHOULD not be 32767 (User-Defined)._
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 27.6 {set:cellbgcolor:#CACCCE}

--- a/GeoTIFF_Standard/standard/requirements/Projection_Definition_Keys/requirements_class_ProjectionGeoKey.adoc
+++ b/GeoTIFF_Standard/standard/requirements/Projection_Definition_Keys/requirements_class_ProjectionGeoKey.adoc
@@ -28,7 +28,8 @@ NOTE: In GeoTIFF v1.0 the range was 10000-19999. Several values in this range ha
 
 |Requirement 26.5 {set:cellbgcolor:#CACCCE}
 |http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.userdefined +
-_If the ProjectionGeoKey value is 32767 (User-Defined) then the ProjectedCitationGeoKey, ProjectionMethodGeoKey, and ProjLinearUnitsGeoKey SHALL be populated_
+_If the ProjectionGeoKey value is 32767 (User-Defined) then the ProjectedCitationGeoKey, ProjMethodGeoKey, ProjLinearUnitsGeoKey
+and keys for each map projection parameter (coordinate operation parameter) appropriate to that method SHALL be populated._
 {set:cellbgcolor:#FFFFFF}
 
 |Requirement 26.6 {set:cellbgcolor:#CACCCE}


### PR DESCRIPTION
This commit moves the following requirement from `ProjMethodGeoKey` to `ProjectionGeoKey`:

> keys for each map projection parameter (coordinate operation parameter) appropriate to that method SHALL be populated.

The previous location was incorrect because projection methods do not contain parameter values. So providing an EPSG code for `ProjMethodGeoKey` is not a replacement to providing parameter values when `ProjectionGeoKey` is user-defined. With this pull request, the new requirement in `ProjectionGeoKey` become (new part in italic):

> If the ProjectionGeoKey value is 32767 (User-Defined) then the ProjectedCitationGeoKey, ProjMethodGeoKey, ProjLinearUnitsGeoKey and _keys for each map projection parameter (coordinate operation parameter) appropriate to that method_ SHALL be populated.

And the old requirement in `ProjMethodGeoKey` become:

> The ProjMethodGeoKey value SHOULD not be 32767 (User-Defined)

The reason for the above is that projection methods are usually mapped to hard-coded formulas in map projection software. If the projection method is not known to the software, there is almost nothing the software can do.

This commit also renames `ProjectionMethodGeoKey` as `ProjMethodGeoKey`. The old name seems a mistake.
